### PR TITLE
EM_JS for post_kernel_message 

### DIFF
--- a/include/xeus-lite/xembind.hpp
+++ b/include/xeus-lite/xembind.hpp
@@ -67,6 +67,13 @@ namespace xeus
             .function("get_server", &get_server, ems::allow_raw_pointers())
             .function("start", &xkernel::start)
         ;
+        // we need a helper function to translate exception ptrs 
+        // to the actual exception message since on the JS side,
+        // we cannot access the exception message directly.
+        ems::function("get_exception_message", 
+            ems::select_overload<std::string(int)>([](int exceptionPtr) {
+            return std::string(reinterpret_cast<std::exception *>(exceptionPtr)->what());
+        }));
     }
 }
 

--- a/share/xeus-lite/worker.ts
+++ b/share/xeus-lite/worker.ts
@@ -164,21 +164,29 @@ class XeusKernel {
     importScripts(WASM_KERNEL_FILE);
 
     globalThis.Module = await createXeusModule({});
-
-    if (DATA_FILE.length !== 0) {
-      importScripts(DATA_FILE);
-      await this.waitRunDependency();
+    try {
+      if (DATA_FILE.length !== 0) {
+        importScripts(DATA_FILE);
+        await this.waitRunDependency();
+      }
+      this._raw_xkernel = new globalThis.Module.xkernel();
+      this._raw_xserver = this._raw_xkernel.get_server();
+      if (!this._raw_xkernel) {
+        console.error('Failed to start kernel!');
+      }
+      this._raw_xkernel.start();
     }
-
-    this._raw_xkernel = new globalThis.Module.xkernel();
-    this._raw_xserver = this._raw_xkernel.get_server();
-
-    if (!this._raw_xkernel) {
-      console.error('Failed to start kernel!');
+    catch (e) {
+        if( typeof e === 'number' ) {
+          const msg = globalThis.Module.get_exception_message(e);
+          console.error(msg);
+          throw new Error(msg);
+        }
+        else {
+          console.error(e);
+          throw(e);
+        }
     }
-
-    this._raw_xkernel.start();
-
     resolve();
   }
 


### PR DESCRIPTION
* remove EM_JS for post_kernel_message (this stoped working downstream) and replace with in place `emscripten::val` calls
*  adding better exception catching